### PR TITLE
Add Pods folder to .gitignore

### DIFF
--- a/_gitignore
+++ b/_gitignore
@@ -21,6 +21,7 @@ DerivedData
 *.ipa
 *.xcuserstate
 project.xcworkspace
+/ios/pods
 
 # Android/IntelliJ
 #


### PR DESCRIPTION
<!-- Thanks for submitting a pull request! We appreciate you spending the time to work on these changes. Please follow the template so that the reviewers can easily understand what the code changes affect -->

# Summary


I had to manually add the `/ios/Pods` folder to my `.gitignore`, after having created a project using `react-native init MyProject --template typescript`. This PR aims to fix that.