### PR TITLE
[cli-v2] Fix pod dependency error

### DIFF
--- a/template/ios/Podfile
+++ b/template/ios/Podfile
@@ -6,6 +6,7 @@ target 'HelloWorld' do
   pod 'React', :path => '../node_modules/react-native/'
   pod 'React-Core', :path => '../node_modules/react-native/React'
   pod 'React-DevSupport', :path => '../node_modules/react-native/React'
+  pod 'React-fishhook', :path => '../node_modules/react-native/Libraries/fishhook'
   pod 'React-RCTActionSheet', :path => '../node_modules/react-native/Libraries/ActionSheetIOS'
   pod 'React-RCTAnimation', :path => '../node_modules/react-native/Libraries/NativeAnimation'
   pod 'React-RCTBlob', :path => '../node_modules/react-native/Libraries/Blob'


### PR DESCRIPTION
# Summary
This PR fixes error when react-native-cli installs pod dependencies. react-native@0.60.0 seems that it still depends on React-fishhook so I added it to the Podfile. https://github.com/facebook/react-native/blob/v0.60.0/template/ios/Podfile#L9.

## Test Plan

This command successfully initializes a new project.
```
npx react-native init MyApp --template=https://github.com/LukeSugiura/react-native-template-typescript#master-cli-v2
```

### What's required for testing (prerequisites)?

### What are the steps to reproduce (after prerequisites)?
```
npx react-native init MyApp --template=react-native-template-typescript@next
```
<img width="847" alt="Screen Shot 2019-07-10 at 12 30 24" src="https://user-images.githubusercontent.com/8398372/60938321-8e132600-a30e-11e9-8030-f1c946b6c35d.png">


## Compatibility

| OS      | Implemented |
| ------- | :---------: |
| iOS     |    ✅❌     |
| Android |    ✅❌     |

## Checklist

- [ ] I have tested this on a device and a simulator
- [ ] I added the documentation in `README.md`
- [ ] I mentioned this change in `CHANGELOG.md`
- [ ] I updated the typed files (TS and Flow)
- [ ] I added a sample use of the API in the example project (`example/App.js`)
