### PR TITLE
Deprecate legacy

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,17 +1,13 @@
 language: node_js
 node_js:
-  - "node"
+  - 'node'
+branches:
+  only:
+    - master
 deploy:
-  - provider: npm
-    on:
-      condition: $TRAVIS_BRANCH == "master" && -n $TRAVIS_TAG
-    email: "emin@emin.ch"
-    api_key: "${NPM_TOKEN}"
-    skip_cleanup: true
-  - provider: npm
-    on:
-      condition: $TRAVIS_BRANCH == "master-cli-v2" && -n $TRAVIS_TAG
-    email: "emin@emin.ch"
-    api_key: "${NPM_TOKEN}"
-    skip_cleanup: true
-    tag: next
+  on:
+    tags: true
+  provider: npm
+  email: 'emin@emin.ch'
+  api_key: '${NPM_TOKEN}'
+  skip_cleanup: true

--- a/README.md
+++ b/README.md
@@ -28,13 +28,7 @@
 ### React Native >= 0.60
 
 ```sh
-npx react-native init MyApp --template react-native-template-typescript@next
-```
-
-### React Native <= 0.59
-
-```sh
-react-native init MyApp --template typescript
+npx react-native init MyApp --template react-native-template-typescript
 ```
 
 ## :computer: Contributing


### PR DESCRIPTION
# Summary

In this PR, I removed support for the legacy version of the template. New tags on master will now trigger a build and release a new version on npm.