### PR TITLE
Update jsx from react to react-native

### DIFF
--- a/template/tsconfig.json
+++ b/template/tsconfig.json
@@ -2,12 +2,12 @@
 {
   "compilerOptions": {
     /* Basic Options */
-    "target": "esnext",                          /* Specify ECMAScript target version: 'ES3' (default), 'ES5', 'ES2015', 'ES2016', 'ES2017','ES2018' or 'ESNEXT'. */
+    "target": "esnext",                       /* Specify ECMAScript target version: 'ES3' (default), 'ES5', 'ES2015', 'ES2016', 'ES2017','ES2018' or 'ESNEXT'. */
     "module": "commonjs",                     /* Specify module code generation: 'none', 'commonjs', 'amd', 'system', 'umd', 'es2015', or 'ESNext'. */
-    "lib": ["es6"],                                /* Specify library files to be included in the compilation. */
+    "lib": ["es6"],                           /* Specify library files to be included in the compilation. */
     "allowJs": true,                          /* Allow javascript files to be compiled. */
     // "checkJs": true,                       /* Report errors in .js files. */
-    "jsx": "react",                           /* Specify JSX code generation: 'preserve', 'react-native', or 'react'. */
+    "jsx": "react-native",                    /* Specify JSX code generation: 'preserve', 'react-native', or 'react'. */
     // "declaration": true,                   /* Generates corresponding '.d.ts' file. */
     // "sourceMap": true,                     /* Generates corresponding '.map' file. */
     // "outFile": "./",                       /* Concatenate and emit output to single file. */


### PR DESCRIPTION
TypeScript ships with a `react-native` [JSX mode](https://www.typescriptlang.org/docs/handbook/jsx.html#basic-usage).

This PR also closes https://github.com/react-native-community/react-native-template-typescript/pull/86 for moving `tsconfig.json` to the right `template` folder. This prevents a merge conflict later on.