### PR TITLE
Fix incorrect init command

### DIFF
--- a/README.md
+++ b/README.md
@@ -28,7 +28,7 @@
 > `react-native@0.61.0` or higher
 
 ```sh
-npx react-native init MyApp --template react-native-template-typescript
+npx react-native init MyApp --template typescript
 ```
 
 > `react-native@0.60.x`


### PR DESCRIPTION
<!-- Thanks for submitting a pull request! We appreciate you spending the time to work on these changes. Please follow the template so that the reviewers can easily understand what the code changes affect -->

# Summary

The command `npx react-native init MyApp --template react-native-template-typescript` leads to https://registry.yarnpkg.com/react-native-template-react-native-template-typescript, which returns `{error: "Not found"}`. 

Removing "react-native-template-" fixes this.

<!--
Explain the **motivation** for making this change: here are some points to help you:

* What issues does the pull request solve? Please tag them so that they will get automatically closed once the PR is merged
* What is the feature? (if applicable)
* How did you implement the solution?
* What areas of the library does it impact?
-->

## Checklist

<!-- Check completed item, when applicable, via: [X] -->

- [x] I have tested this on a device and a simulator
- [ ] I added the documentation in `README.md`
- [ ] I mentioned this change in `CHANGELOG.md`
- [ ] I updated the typed files (TS and Flow)
- [ ] I added a sample use of the API in the example project (`example/App.js`)
