### PR TITLE
Upgrade typescript to 3.7.3.

### DIFF
--- a/template/package.json
+++ b/template/package.json
@@ -23,7 +23,7 @@
     "jest": "^24.9.0",
     "metro-react-native-babel-preset": "^0.56.0",
     "react-test-renderer": "16.9.0",
-    "typescript": "^3.6.3"
+    "typescript": "^3.7.3"
   },
   "jest": {
     "preset": "react-native",


### PR DESCRIPTION
# Summary

Resolves https://github.com/react-native-community/react-native-template-typescript/issues/99

Updated Typescript version to 3.7.3 and confirmed that optional chaining works in fresh project.

## Test Plan

Create a new component which takes in an optional prop:
``` typescript
import React from 'react';
import {Text} from 'react-native';

interface Props {
  optionalFunction?: () => void;
}

const Test = ({optionalFunction}: Props) => {
  optionalFunction?.();
  return <Text>Testing optional chaining</Text>;
};

export default Test;
```

Include this new component in `App.tsx` and test passing a valid or undefined function. If the function is defined then it should execute before rendering. Something simple like `() => console.log('Optional changing works!')` is an easy check.

## Compatibility

| OS      | Implemented |
| ------- | :---------: |
| iOS     |    ✅     |
| Android |    ✅     |

## Checklist

<!-- Check completed item, when applicable, via: [X] -->

- [x] I have tested this on a device and a simulator
- [ ] I added the documentation in `README.md`
- [ ] I mentioned this change in `CHANGELOG.md`
- [ ] I updated the typed files (TS and Flow)
- [ ] I added a sample use of the API in the example project (`example/App.js`)
