### PR TITLE
Removed baseUrl from .tsconfig

### DIFF
--- a/template/tsconfig.json
+++ b/template/tsconfig.json
@@ -37,7 +37,7 @@
 
     /* Module Resolution Options */
     "moduleResolution": "node",               /* Specify module resolution strategy: 'node' (Node.js) or 'classic' (TypeScript pre-1.6). */
-    "baseUrl": "./",                          /* Base directory to resolve non-absolute module names. */
+    // "baseUrl": "./",                       /* Base directory to resolve non-absolute module names. */
     // "paths": {},                           /* A series of entries which re-map imports to lookup locations relative to the 'baseUrl'. */
     // "rootDirs": [],                        /* List of root folders whose combined content represents the structure of the project at runtime. */
     // "typeRoots": [],                       /* List of folders to include type definitions from. */


### PR DESCRIPTION
# Summary

Removed `baseUrl` from `.tsconfig` as this causes several IDEs to do the auto imports wrong.

Either include it in the babel config as well or remove it from the `.tsconfig`, because now there's a mismatch between the tsconfig and the babel config.
