### PR TITLE
Fix lib to use iOS 10.x and Android JSC

### DIFF
--- a/template/tsconfig.json
+++ b/template/tsconfig.json
@@ -4,7 +4,7 @@
     /* Basic Options */
     "target": "esnext",                       /* Specify ECMAScript target version: 'ES3' (default), 'ES5', 'ES2015', 'ES2016', 'ES2017','ES2018' or 'ESNEXT'. */
     "module": "commonjs",                     /* Specify module code generation: 'none', 'commonjs', 'amd', 'system', 'umd', 'es2015', or 'ESNext'. */
-    "lib": ["es6"],                           /* Specify library files to be included in the compilation. */
+    "lib": ["es2017"],                        /* Specify library files to be included in the compilation. */
     "allowJs": true,                          /* Allow javascript files to be compiled. */
     // "checkJs": true,                       /* Report errors in .js files. */
     "jsx": "react-native",                    /* Specify JSX code generation: 'preserve', 'react-native', or 'react'. */


### PR DESCRIPTION
# Summary

Now that React Native 0.63 requires iOS 10.x, and bundles a modern version of JSC on Android, we can update the JavaScript library version to es2017. That brings in declarations for:
- `Array.prototype.includes`
- `Object.entries` and `Object.values`
- `String.padStart` and `String.padEnd`

Also, the version of Node that React Native requires, 10.x, also supports these APIs.

## Test Plan

Ran `yarn run tsc` in the template application and no errors were found.

### What's required for testing (prerequisites)?

N/A

### What are the steps to reproduce (after prerequisites)?

N/A

## Compatibility

| OS      | Implemented |
| ------- | :---------: |
| iOS     |    ✅     |
| Android |    ✅     |

## Checklist

<!-- Check completed item, when applicable, via: [X] -->

- [ ] I have tested this on a device and a simulator
- [ ] I added the documentation in `README.md`
- [ ] I mentioned this change in `CHANGELOG.md`
- [ ] I updated the typed files (TS and Flow)
- [ ] I added a sample use of the API in the example project (`example/App.js`)
