### PR TITLE
sync latest rn 

### DIFF
--- a/template/android/gradle.properties
+++ b/template/android/gradle.properties
@@ -25,4 +25,4 @@ android.useAndroidX=true
 android.enableJetifier=true
 
 # Version of flipper SDK to use with React Native
-FLIPPER_VERSION=0.37.0
+FLIPPER_VERSION=0.54.0

--- a/template/package.json
+++ b/template/package.json
@@ -11,7 +11,7 @@
   },
   "dependencies": {
     "react": "16.13.1",
-    "react-native": "0.63.2"
+    "react-native": "0.63.3"
   },
   "devDependencies": {
     "@babel/core": "^7.8.4",


### PR DESCRIPTION
Thought it might make sense to re-sync the template again with the latest RN template and there are in fact a few things we didn't take over yet.

Template source as usual from the official RN repo (tag v0.63.3): https://github.com/facebook/react-native/tree/v0.63.3/template