### PR TITLE
Fix compile errors with skip lib check

### DIFF
--- a/template/tsconfig.json
+++ b/template/tsconfig.json
@@ -43,8 +43,9 @@
     // "typeRoots": [],                       /* List of folders to include type definitions from. */
     // "types": [],                           /* Type declaration files to be included in compilation. */
     "allowSyntheticDefaultImports": true,     /* Allow default imports from modules with no default export. This does not affect code emit, just typechecking. */
-    "esModuleInterop": true                   /* Enables emit interoperability between CommonJS and ES Modules via creation of namespace objects for all imports. Implies 'allowSyntheticDefaultImports'. */
+    "esModuleInterop": true,                  /* Enables emit interoperability between CommonJS and ES Modules via creation of namespace objects for all imports. Implies 'allowSyntheticDefaultImports'. */
     // "preserveSymlinks": true,              /* Do not resolve the real path of symlinks. */
+    "skipLibCheck": true                      /* Skip type checking of declaration files. */
 
     /* Source Map Options */
     // "sourceRoot": "./",                    /* Specify the location where debugger should locate TypeScript files instead of source locations. */


### PR DESCRIPTION
# Summary
Currently running the Typescript compiler on the template throws over 177 errors (See gist https://gist.github.com/sshquack/1e0d1425a10fbfa2b6eab91c8eeda235#file-rn-tsc-errors for full list of errors).

## Root cause

All the errors are because `tsc` is finding duplicate types exposed in the `node_modules`. The fix is to skip the library check while doing type resolution per the compiler flag `skipLibCheck` https://www.typescriptlang.org/tsconfig#skipLibCheck

## Before

```
$ yarn run tsc
node_modules/@types/react-test-renderer/node_modules/@types/react/index.d.ts(2982,14): error TS2300: Duplicate identifier 'LibraryManagedAttributes'.
node_modules/@types/react-test-renderer/node_modules/@types/react/index.d.ts(2995,13): error TS2717: Subsequent property declarations must have the same type.  Property 'a' must be of type 'DetailedHTMLProps<AnchorHTMLAttributes<HTMLAnchorElement>, HTMLAnchorElement>', but here has type 'DetailedHTMLProps<AnchorHTMLAttributes<HTMLAnchorElement>, HTMLAnchorElement>'.
node_modules/@types/react-test-renderer/node_modules/@types/react/index.d.ts(2996,13): error TS2717: Subsequent property declarations must have the same type.  Property 'abbr' must be of type 'DetailedHTMLProps<HTMLAttributes<HTMLElement>, HTMLElement>', but here has type 'DetailedHTMLProps<HTMLAttributes<HTMLElement>, HTMLElement>'.
...

Found 177 errors.

$ echo $?
1
```

## After
```
$ yarn run tsc

$ echo $?
0
```

## References

It looks like a bunch of folks have tripped over this issue according to StackOverflow. See https://stackoverflow.com/questions/54135918/typescript-and-react-native-hundreds-of-errors-from-node-modules-types-when-co

## Verification

```
$ yarn run tsc ✔️
$ yarn run test ✔️
```