### PR TITLE
Prevent installing multiple versions of `@types/react`

### DIFF
--- a/template/package.json
+++ b/template/package.json
@@ -27,6 +27,9 @@
     "react-test-renderer": "16.13.1",
     "typescript": "^3.8.3"
   },
+  "resolutions": {
+    "@types/react": "^16"
+  },
   "jest": {
     "preset": "react-native",
     "moduleFileExtensions": [

--- a/template/tsconfig.json
+++ b/template/tsconfig.json
@@ -45,7 +45,7 @@
     "allowSyntheticDefaultImports": true,     /* Allow default imports from modules with no default export. This does not affect code emit, just typechecking. */
     "esModuleInterop": true,                  /* Enables emit interoperability between CommonJS and ES Modules via creation of namespace objects for all imports. Implies 'allowSyntheticDefaultImports'. */
     // "preserveSymlinks": true,              /* Do not resolve the real path of symlinks. */
-    "skipLibCheck": true                      /* Skip type checking of declaration files. */
+    "skipLibCheck": false                      /* Skip type checking of declaration files. */
 
     /* Source Map Options */
     // "sourceRoot": "./",                    /* Specify the location where debugger should locate TypeScript files instead of source locations. */


### PR DESCRIPTION
This is an alternative to #181 to fix the compile errors from type checking dependencies. The compiler errors are caused by multiple copies of `@types/react` being brought in by yarn. This happens because both `@types/react-native` and `@types/react-test-renderer` declare a dependency on `@types/react`, but they have different version dependencies, which causes duplication:

```
"@types/react-native@^0.63.2":
  version "0.63.49"
  resolved "https://registry.yarnpkg.com/@types/react-native/-/react-native-0.63.49.tgz#b9a4781a0543763f0079c3ef2ba2148a4509b32e"
  dependencies:
    "@types/react" "*"

"@types/react-test-renderer@^16.9.2":
  version "16.9.5"
  resolved "https://registry.yarnpkg.com/@types/react-test-renderer/-/react-test-renderer-16.9.5.tgz#edab67da470f7c3e997f58d55dcfe2643cc30a68"
  dependencies:
    "@types/react" "^16"

"@types/react@*":
  version "17.0.2"
  resolved "https://registry.yarnpkg.com/@types/react/-/react-17.0.2.tgz#3de24c4efef902dd9795a49c75f760cbe4f7a5a8"
  dependencies:
    "@types/prop-types" "*"
    csstype "^3.0.2"

"@types/react@^16":
  version "16.14.4"
  resolved "https://registry.yarnpkg.com/@types/react/-/react-16.14.4.tgz#365f6a1e117d1eec960ba792c7e1e91ecad38e6f"
  dependencies:
    "@types/prop-types" "*"
    csstype "^3.0.2"
```

This PR resolves this by forcing the resolution of `@types/react@*` to match `@types/react@^16`. Then type-checking can be re-enabled for 3rd party libraries.

When we upgrade to React Native 0.64, which includes React 17.0.1, this resolution will have to be updated as well.
