### PR TITLE
deps: bump @types/react-native to 0.64.0

### DIFF
--- a/template/package.json
+++ b/template/package.json
@@ -18,7 +18,7 @@
     "@babel/runtime": "^7.12.5",
     "@react-native-community/eslint-config": "^2.0.0",
     "@types/jest": "^26.0.20",
-    "@types/react-native": "^0.63.51",
+    "@types/react-native": "^0.64.0",
     "@types/react-test-renderer": "^16.9.2",
     "babel-jest": "^26.6.3",
     "eslint": "^7.14.0",


### PR DESCRIPTION
typings for RN0.64 has been released and we should make the change here as well .