### PR TITLE
Update documentation to have CLI instructions before the usage

### DIFF
--- a/README.md
+++ b/README.md
@@ -23,6 +23,12 @@
 - Consistent with the default React Native template
 - Minimal additional dependencies
 
+## :warning: React Native CLI
+
+This template only works with the new CLI. Make sure you have uninstalled the legacy `react-native-cli` first (`npm uninstall -g react-native-cli`), for the below command to work. If you wish to not use `npx`, you can also install the new CLI globally (`npm i -g @react-native-community/cli` or `yarn global add @react-native-community/cli`).
+
+Further information can be found here: https://github.com/react-native-community/cli#about
+
 ## :arrow_forward: Usage
 
 ```sh
@@ -41,18 +47,13 @@ See the below table to find out which version of the template to use.
 
 #### React Native <=> Template Version
 
-| React Native  	| Template  	|
-|---	            |---	        |
-| 0.64  	        | 6.6.*       |
-| 0.63  	        | 6.5.*       |
-| 0.62  	        | 6.4.*       |
-| 0.61  	        | 6.3.*       |
-| 0.60  	        | 6.2.*       |
-
-### Note on the legacy CLI
-There seems to be quite some confusion about the legacy CLI. This template only works with the new CLI. Make sure you have uninstalled the legacy `react-native-cli` first (`npm uninstall -g react-native-cli`), for the below command to work. If you wish to not use `npx`, you can also install the new CLI globally (`npm i -g @react-native-community/cli` or `yarn global add @react-native-community/cli`).
-
-Further information can be found here: https://github.com/react-native-community/cli#about
+| React Native | Template |
+| ------------ | -------- |
+| 0.64         | 6.6.\*   |
+| 0.63         | 6.5.\*   |
+| 0.62         | 6.4.\*   |
+| 0.61         | 6.3.\*   |
+| 0.60         | 6.2.\*   |
 
 ## :computer: Contributing
 

--- a/README.md
+++ b/README.md
@@ -53,6 +53,14 @@ See the below table to find out which version of the template to use.
 
 This template only works with the new CLI. Make sure you have uninstalled the legacy `react-native-cli` first (`npm uninstall -g react-native-cli`), for the below command to work. If you wish to not use `npx`, you can also install the new CLI globally (`npm i -g @react-native-community/cli` or `yarn global add @react-native-community/cli`).
 
+### Using this template with the old CLI
+If you need the old CLI and don't want to update it, the [--ignore-existing](https://github.com/npm/npx#description) flag makes this template to work without any updates.
+
+Usage example:
+```
+npx --ignore-existing react-native init MyApp --template react-native-template-typescript
+```
+
 Further information can be found here: https://github.com/react-native-community/cli#about
 ## :computer: Contributing
 

--- a/README.md
+++ b/README.md
@@ -23,12 +23,6 @@
 - Consistent with the default React Native template
 - Minimal additional dependencies
 
-## :warning: React Native CLI
-
-This template only works with the new CLI. Make sure you have uninstalled the legacy `react-native-cli` first (`npm uninstall -g react-native-cli`), for the below command to work. If you wish to not use `npx`, you can also install the new CLI globally (`npm i -g @react-native-community/cli` or `yarn global add @react-native-community/cli`).
-
-Further information can be found here: https://github.com/react-native-community/cli#about
-
 ## :arrow_forward: Usage
 
 ```sh
@@ -55,6 +49,11 @@ See the below table to find out which version of the template to use.
 | 0.61         | 6.3.\*   |
 | 0.60         | 6.2.\*   |
 
+## :warning: React Native CLI
+
+This template only works with the new CLI. Make sure you have uninstalled the legacy `react-native-cli` first (`npm uninstall -g react-native-cli`), for the below command to work. If you wish to not use `npx`, you can also install the new CLI globally (`npm i -g @react-native-community/cli` or `yarn global add @react-native-community/cli`).
+
+Further information can be found here: https://github.com/react-native-community/cli#about
 ## :computer: Contributing
 
 Contributions are very welcome. Please check out the [contributing document](CONTRIBUTING.md).

--- a/README.md
+++ b/README.md
@@ -53,13 +53,8 @@ See the below table to find out which version of the template to use.
 
 This template only works with the new CLI. Make sure you have uninstalled the legacy `react-native-cli` first (`npm uninstall -g react-native-cli`), for the below command to work. If you wish to not use `npx`, you can also install the new CLI globally (`npm i -g @react-native-community/cli` or `yarn global add @react-native-community/cli`).
 
-### Using this template with the old CLI
-If you need the old CLI and don't want to update it, the [--ignore-existing](https://github.com/npm/npx#description) flag makes this template to work without any updates.
+If you tried the above and still get the *react-native-template-react- native-template-typescript: Not found error*, please try adding the [--ignore-existing](https://github.com/npm/npx#description) flag to the npx call to force npx to ignore any locally installed versions of the CLI.
 
-Usage example:
-```
-npx --ignore-existing react-native init MyApp --template react-native-template-typescript
-```
 
 Further information can be found here: https://github.com/react-native-community/cli#about
 ## :computer: Contributing


### PR DESCRIPTION
## Why?
This is a suggestion to improve the communication about the React Native CLI. As it works only with the new CLI, it seems to be a requirement instead of a note.

The goal here is to avoid issues like this one https://github.com/facebook/react-native/issues/31054.