### PR TITLE
upgrade to rn 0.64.1 and update type defs

### DIFF
--- a/template/package.json
+++ b/template/package.json
@@ -11,14 +11,14 @@
   },
   "dependencies": {
     "react": "17.0.1",
-    "react-native": "0.64.0"
+    "react-native": "0.64.1"
   },
   "devDependencies": {
     "@babel/core": "^7.12.9",
     "@babel/runtime": "^7.12.5",
     "@react-native-community/eslint-config": "^2.0.0",
-    "@types/jest": "^26.0.20",
-    "@types/react-native": "^0.64.0",
+    "@types/jest": "^26.0.23",
+    "@types/react-native": "^0.64.5",
     "@types/react-test-renderer": "^16.9.2",
     "babel-jest": "^26.6.3",
     "eslint": "^7.14.0",


### PR DESCRIPTION
Note: While the upgrade helper shows a modified `project.pbxproj`:
https://react-native-community.github.io/upgrade-helper/?from=0.64.0&to=0.64.1

this file hasn't been updated in the RN repo:
https://github.com/facebook/react-native/blob/v0.64.1/template/ios/HelloWorld.xcodeproj/project.pbxproj