### PR TITLE
Update _gitignore

### DIFF
--- a/template/_gitignore
+++ b/template/_gitignore
@@ -28,6 +28,7 @@ build/
 .gradle
 local.properties
 *.iml
+*.hprof
 
 # node.js
 #


### PR DESCRIPTION
.hprof files are generated when building an apk, its size > 300 MB and it's not part of the code so we don't wont that in the repo