### PR TITLE
Allow TypeScript to resolve JSON modules

### DIFF
--- a/template/tsconfig.json
+++ b/template/tsconfig.json
@@ -45,7 +45,8 @@
     "allowSyntheticDefaultImports": true,     /* Allow default imports from modules with no default export. This does not affect code emit, just typechecking. */
     "esModuleInterop": true,                  /* Enables emit interoperability between CommonJS and ES Modules via creation of namespace objects for all imports. Implies 'allowSyntheticDefaultImports'. */
     // "preserveSymlinks": true,              /* Do not resolve the real path of symlinks. */
-    "skipLibCheck": false                      /* Skip type checking of declaration files. */
+    "skipLibCheck": false,                    /* Skip type checking of declaration files. */
+    "resolveJsonModule": true                 /* Allows importing modules with a ‘.json’ extension, which is a common practice in node projects. */
 
     /* Source Map Options */
     // "sourceRoot": "./",                    /* Specify the location where debugger should locate TypeScript files instead of source locations. */


### PR DESCRIPTION
I can't find any reason why this isn't enabled already and it was added in TypeScript 2.9 so should work for everyone.