### PR TITLE
fix(lint): typescript requires special no-shadow

### DIFF
--- a/template/_eslintrc.js
+++ b/template/_eslintrc.js
@@ -1,4 +1,8 @@
 module.exports = {
   root: true,
   extends: '@react-native-community',
+  rules: {
+    "no-shadow": "off",
+    "@typescript-eslint/no-shadow": ["error"],
+  },
 };


### PR DESCRIPTION
In pure javascript eslint config from `@react-native-community`, the no-shadow rule is on,
which is good, but for typescript it generates false-positives and needs a specific configuration change
to use a typescript-specific rule

Reference: 
- Rule: https://github.com/typescript-eslint/typescript-eslint/blob/main/packages/eslint-plugin/docs/rules/no-shadow.md
- Problems: https://github.com/typescript-eslint/typescript-eslint/issues/2552#issuecomment-691694839