### PR TITLE
Fix ESLint setup

### DIFF
--- a/template/_eslintrc.js
+++ b/template/_eslintrc.js
@@ -1,8 +1,10 @@
 module.exports = {
   root: true,
   extends: '@react-native-community',
+  parser: '@typescript-eslint/parser',
+  plugins: ['@typescript-eslint'],
   rules: {
-    "no-shadow": "off",
-    "@typescript-eslint/no-shadow": ["error"],
+    'no-shadow': 'off',
+    '@typescript-eslint/no-shadow': ['error'],
   },
 };

--- a/template/package.json
+++ b/template/package.json
@@ -20,6 +20,8 @@
     "@types/jest": "^26.0.23",
     "@types/react-native": "^0.66.4",
     "@types/react-test-renderer": "^17.0.1",
+    "@typescript-eslint/eslint-plugin": "^5.7.0",
+    "@typescript-eslint/parser": "^5.7.0",
     "babel-jest": "^26.6.3",
     "eslint": "^7.14.0",
     "jest": "^26.6.3",


### PR DESCRIPTION
There are several issues related to the current ESLint/TypeScript setup with the latest version of this template.

Steps to reproduce:

1. Create new project: `npx react-native init rntsapp --template react-native-template-typescript`
2. Run `yarn lint`
3. Observe errors

```
error  Definition for rule '@typescript-eslint/no-shadow' was not found  @typescript-eslint/no-shadow
```

and

```
WARNING: You are currently running a version of TypeScript which is not officially supported by @typescript-eslint/typescript-estree.
```

Also, `.eslintrc.js` contained a few quote warnings/errors that were also fixed.

```
/path/rntsapp/.eslintrc.js
  1:1   error    Definition for rule '@typescript-eslint/no-shadow' was not found                                    @typescript-eslint/no-shadow
  5:5   error    Replace `"no-shadow":·"off"` with `'no-shadow':·'off'`                                              prettier/prettier
  5:5   warning  Strings must use singlequote                                                                        quotes
  5:18  warning  Strings must use singlequote                                                                        quotes
  6:5   error    Replace `"@typescript-eslint/no-shadow":·["error"` with `'@typescript-eslint/no-shadow':·['error'`  prettier/prettier
  6:5   warning  Strings must use singlequote                                                                        quotes
  6:38  warning  Strings must use singlequote                                                                        quotes
```

Related: #112 #150 #238

Fixes #237 