### PR TITLE
Update ESLint config

### DIFF
--- a/template/_eslintrc.js
+++ b/template/_eslintrc.js
@@ -3,8 +3,14 @@ module.exports = {
   extends: '@react-native-community',
   parser: '@typescript-eslint/parser',
   plugins: ['@typescript-eslint'],
-  rules: {
-    'no-shadow': 'off',
-    '@typescript-eslint/no-shadow': ['error'],
-  },
+  overrides: [
+    {
+      files: ['*.ts', '*.tsx'],
+      rules: {
+        '@typescript-eslint/no-shadow': ['error'],
+        'no-shadow': 'off',
+        'no-undef': 'off',
+      },
+    },
+  ],
 };


### PR DESCRIPTION
A couple of minor updates to the ESLint config:

- Move rules into an `overrides` section, as these should only be applied to TypeScript files (`.ts`/`.tsx`)
- Disable `no-undef`

The reason for disabling `no-undef` can be found in the [official typescript-eslint docs](https://github.com/typescript-eslint/typescript-eslint/blob/main/docs/linting/TROUBLESHOOTING.md#i-get-errors-from-the-no-undef-rule-about-global-variables-not-being-defined-even-though-there-are-no-typescript-errors):

> We strongly recommend that you do not use the no-undef lint rule on TypeScript projects. The checks it provides are already provided by TypeScript without the need for configuration - TypeScript just does this significantly better.