### PR TITLE
set skipLibCheck to true in tsconfig

### DIFF
--- a/template/tsconfig.json
+++ b/template/tsconfig.json
@@ -45,7 +45,7 @@
     "allowSyntheticDefaultImports": true,     /* Allow default imports from modules with no default export. This does not affect code emit, just typechecking. */
     "esModuleInterop": true,                  /* Enables emit interoperability between CommonJS and ES Modules via creation of namespace objects for all imports. Implies 'allowSyntheticDefaultImports'. */
     // "preserveSymlinks": true,              /* Do not resolve the real path of symlinks. */
-    "skipLibCheck": false,                    /* Skip type checking of declaration files. */
+    "skipLibCheck": true,                     /* Skip type checking of declaration files. */
     "resolveJsonModule": true                 /* Allows importing modules with a ‘.json’ extension, which is a common practice in node projects. */
 
     /* Source Map Options */


### PR DESCRIPTION
when running `tsc` on a project inited with this template (v6.9.0), the following errors are thrown:

```
node_modules/@types/node/globals.d.ts:47:11 - error TS2300: Duplicate identifier 'AbortController'.

47 interface AbortController {
             ~~~~~~~~~~~~~~~

  node_modules/@types/react-native/globals.d.ts:435:15
    435 declare class AbortController {
                      ~~~~~~~~~~~~~~~
    'AbortController' was also declared here.

node_modules/@types/node/globals.d.ts:60:11 - error TS2300: Duplicate identifier 'AbortSignal'.

60 interface AbortSignal {
             ~~~~~~~~~~~

  node_modules/@types/react-native/globals.d.ts:400:15
    400 declare class AbortSignal implements EventTarget {
                      ~~~~~~~~~~~
    'AbortSignal' was also declared here.

node_modules/@types/node/globals.d.ts:67:13 - error TS2300: Duplicate identifier 'AbortController'.

67 declare var AbortController: {
               ~~~~~~~~~~~~~~~

  node_modules/@types/react-native/globals.d.ts:435:15
    435 declare class AbortController {
                      ~~~~~~~~~~~~~~~
    'AbortController' was also declared here.

node_modules/@types/node/globals.d.ts:72:13 - error TS2300: Duplicate identifier 'AbortSignal'.

72 declare var AbortSignal: {
               ~~~~~~~~~~~

  node_modules/@types/react-native/globals.d.ts:400:15
    400 declare class AbortSignal implements EventTarget {
                      ~~~~~~~~~~~
    'AbortSignal' was also declared here.

node_modules/@types/react-native/globals.d.ts:400:15 - error TS2300: Duplicate identifier 'AbortSignal'.

400 declare class AbortSignal implements EventTarget {
                  ~~~~~~~~~~~

  node_modules/@types/node/globals.d.ts:60:11
    60 interface AbortSignal {
                 ~~~~~~~~~~~
    'AbortSignal' was also declared here.
  node_modules/@types/node/globals.d.ts:72:13
    72 declare var AbortSignal: {
                   ~~~~~~~~~~~
    and here.

node_modules/@types/react-native/globals.d.ts:435:15 - error TS2300: Duplicate identifier 'AbortController'.

435 declare class AbortController {
                  ~~~~~~~~~~~~~~~

  node_modules/@types/node/globals.d.ts:47:11
    47 interface AbortController {
                 ~~~~~~~~~~~~~~~
    'AbortController' was also declared here.
  node_modules/@types/node/globals.d.ts:67:13
    67 declare var AbortController: {
                   ~~~~~~~~~~~~~~~
    and here.
```

Setting [skipLibCheck](https://www.typescriptlang.org/tsconfig#skipLibCheck) to true avoids duplication errors and also save time during compilation