### PR TITLE
update template dependencies to match upstream

### DIFF
--- a/template/package.json
+++ b/template/package.json
@@ -23,9 +23,9 @@
     "@typescript-eslint/eslint-plugin": "^5.7.0",
     "@typescript-eslint/parser": "^5.7.0",
     "babel-jest": "^26.6.3",
-    "eslint": "^7.14.0",
+    "eslint": "^7.32.0",
     "jest": "^26.6.3",
-    "metro-react-native-babel-preset": "^0.66.2",
+    "metro-react-native-babel-preset": "^0.69.1",
     "react-test-renderer": "17.0.2",
     "typescript": "^4.4.4"
   },


### PR DESCRIPTION
The upstream React Native package template has more recent dependencies in its package.json file. This PR brings these up to parity.

https://github.com/facebook/react-native/blob/main/template/package.json