### PR TITLE
Put the template in quotes when an asterisk is used

### DIFF
--- a/README.md
+++ b/README.md
@@ -34,7 +34,7 @@ npx react-native init MyApp --template react-native-template-typescript
 #### e.g. `react-native@0.67.x`
 
 ```sh
-npx react-native init MyApp --template react-native-template-typescript@6.9.*
+npx react-native init MyApp --template "react-native-template-typescript@6.9.*"
 ```
 
 See the below table to find out which version of the template to use.


### PR DESCRIPTION
I needed to wrap the template name in quotes to get it to work in `zsh` so I thought it might be good to change the docs as, as far as I'm aware, the quotes would not cause any problems for other terminal environments.

Running the command without quotes:

```
npx react-native init Foo --template react-native-template-typescript@6.8.*
zsh: no matches found: react-native-template-typescript@6.8.*
```