### PR TITLE
Add Section Component prop type

### DIFF
--- a/template/App.tsx
+++ b/template/App.tsx
@@ -28,6 +28,7 @@ import {
 } from 'react-native/Libraries/NewAppScreen';
 
 const Section: React.FC<{
+  children: React.ReactNode;
   title: string;
 }> = ({children, title}) => {
   const isDarkMode = useColorScheme() === 'dark';


### PR DESCRIPTION
The React 18 update eliminates children from the React.FC default type. Apply the resulting changes