### PR TITLE
Add @types/react to devDependencies

### DIFF
--- a/template/package.json
+++ b/template/package.json
@@ -19,6 +19,7 @@
     "@react-native-community/eslint-config": "^2.0.0",
     "@tsconfig/react-native": "^2.0.2",
     "@types/jest": "^26.0.23",
+    "@types/react": "^18.0.21",
     "@types/react-native": "^0.70.4",
     "@types/react-test-renderer": "^18.0.0",
     "@typescript-eslint/eslint-plugin": "^5.37.0",


### PR DESCRIPTION
As discussed in #298, if we decide to add `@types/react` to the template this PR should work