### PR TITLE
fix: syntax error in iOS xcodeproject

### DIFF
--- a/template/ios/HelloWorld.xcodeproj/project.pbxproj
+++ b/template/ios/HelloWorld.xcodeproj/project.pbxproj
@@ -562,7 +562,7 @@
 				COPY_PHASE_STRIP = NO;
 				ENABLE_STRICT_OBJC_MSGSEND = YES;
 				ENABLE_TESTABILITY = YES;
-				"EXCLUDED_ARCHS[sdk=iphonesimulator*]" = ”;
+				"EXCLUDED_ARCHS[sdk=iphonesimulator*]" = "";
 				GCC_C_LANGUAGE_STANDARD = gnu99;
 				GCC_DYNAMIC_NO_PIC = NO;
 				GCC_NO_COMMON_BLOCKS = YES;


### PR DESCRIPTION
Fixes regression caused by:#308

See: https://github.com/react-native-community/react-native-template-typescript/pull/308/files#diff-5e5f05dcdf7a14aea292c3172649e6a220923662fdb41d409997c37da721d27eR565


```
pod install

.rbenv/versions/2.7.1/lib/ruby/gems/2.7.0/gems/nanaimo-0.3.0/lib/nanaimo/reader.rb:284:in `raise_parser_error': [!] Invalid character "\\xE2" in unquoted string (Nanaimo::Reader::ParseError)
   #  -------------------------------------------
   #                            ENABLE_STRICT_OBJC_MSGSEND = YES;
   #                            ENABLE_TESTABILITY = YES;
565>                            "EXCLUDED_ARCHS[sdk=iphonesimulator*]" = ”;
                                                                         ^
   #                            GCC_C_LANGUAGE_STANDARD = gnu99;
   #                            GCC_DYNAMIC_NO_PIC = NO;
   #  -------------------------------------------
```