### PR TITLE
Update Ruby version to match react-native repo

### DIFF
--- a/template/Gemfile
+++ b/template/Gemfile
@@ -1,6 +1,6 @@
 source 'https://rubygems.org'
 
 # You may use http://rbenv.org/ or https://rvm.io/ to install and use this version
-ruby '2.7.5'
+ruby '2.7.6'
 
 gem 'cocoapods', '~> 1.11', '>= 1.11.2'


### PR DESCRIPTION
Make sure that the Ruby version used in this template matches that of the main `react-native` repo.

[The main `react-native` repo uses ruby version `2.7.6`](https://github.com/facebook/react-native/blob/main/template/_ruby-version); this typescript template uses `2.7.5`.

(Following the [current React Native setup instructions](https://reactnative.dev/docs/environment-setup) with this typescript template fails because the versions are not synced).