### PR TITLE
feat: update to react-native@0.70.10

### DIFF
--- a/template/Gemfile
+++ b/template/Gemfile
@@ -3,4 +3,4 @@ source 'https://rubygems.org'
 # You may use http://rbenv.org/ or https://rvm.io/ to install and use this version
 ruby '2.7.5'
 
-gem 'cocoapods', '~> 1.11', '>= 1.11.2'
+gem 'cocoapods', '~> 1.11', '>= 1.11.3'

--- a/template/package.json
+++ b/template/package.json
@@ -11,7 +11,7 @@
   },
   "dependencies": {
     "react": "18.1.0",
-    "react-native": "0.70.6"
+    "react-native": "0.70.10"
   },
   "devDependencies": {
     "@babel/core": "^7.12.9",


### PR DESCRIPTION
The template should update to the latest minor changes the version 0.70.10

Different for updating is safe https://react-native-community.github.io/upgrade-helper/?from=0.70.6&to=0.70.10

Version 0.70.10 fixes the build failed issue in iOS 12.0 that mentioned in https://github.com/facebook/react-native/issues/34106#issuecomment-1601242383